### PR TITLE
Disable integration tests and docker startup by default in jenkinsfile functions

### DIFF
--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -40,7 +40,7 @@ def build_library(repo, branch, mvnparams){
     sh("git remote get-url origin >> ${build_txt}")
     sh("git symbolic-ref -q --short HEAD >> ${build_txt} || git describe --tags --exact-match >> ${build_txt}")
     sh("git log --pretty=full -n 1 >> ${build_txt}")
-    sh("mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}")
+    sh("mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install -DskipITs -Ddocker.skip ${mvnparams}")
   }
 }
 
@@ -63,7 +63,7 @@ def build_war(repo, mvnparams) {
       sh "git symbolic-ref -q --short HEAD >> ${build_txt} || git describe --tags --exact-match >> ${build_txt}"
     }
     sh "git log --pretty=medium -n 1 >> ${build_txt}"
-    sh "mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}"
+    sh "mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install -DskipITs -Ddocker.skip ${mvnparams}"
   }
 }
 


### PR DESCRIPTION
Once this change is deployed, these flags can be removed from the ingest jenkinsfile:

https://github.com/CDLUC3/mrt-ingest/blob/84611e589fd0ec2957e03d1b602261abb1fbe39b/Jenkinsfile#L68