### PR TITLE
Use ECR environment variables in build script

### DIFF
--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -37,6 +37,7 @@ def init_build() {
     def aws_account_id = sh(script: "aws sts get-caller-identity| jq -r .Account", returnStdout: true).toString().trim()
     def aws_region = "us-west-2"
     def ecr_registry = "${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com"
+    sh("newgrp docker")
     sh("aws ecr get-login-password --region ${aws_region} | docker login --username AWS --password-stdin ${ecr_registry}")
     sh("export AWS_ACCOUNT_ID=${aws_account_id}")
   }

--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -37,7 +37,9 @@ def init_build() {
     def aws_account_id = sh(script: "aws sts get-caller-identity| jq -r .Account", returnStdout: true).toString().trim()
     def aws_region = "us-west-2"
     def ecr_registry = "${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com"
+    sh("groups")
     sh("newgrp docker")
+    sh("groups")
     sh("aws ecr get-login-password --region ${aws_region} | docker login --username AWS --password-stdin ${ecr_registry}")
     sh("export AWS_ACCOUNT_ID=${aws_account_id}")
   }

--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -17,6 +17,8 @@ Environment
 
 def init_build() {
   script {
+    sh("echo whoami")
+    sh("whoami")
     sh("mkdir -p static")
     def build_txt = 'static/build.content.txt'
     if (params.containsKey("branch")) {

--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -45,11 +45,12 @@ def build_library(repo, branch, mvnparams){
   script {
     def build_txt = '../static/build.content.txt'
     def aws_account_id = sh(script: "aws sts get-caller-identity| jq -r .Account", returnStdout: true).toString().trim()
+    def aws_region = "us-west-2"
     git branch: branch, url: repo
     sh("git remote get-url origin >> ${build_txt}")
     sh("git symbolic-ref -q --short HEAD >> ${build_txt} || git describe --tags --exact-match >> ${build_txt}")
     sh("git log --pretty=full -n 1 >> ${build_txt}")
-    sh("AWS_ACCOUNT_ID=${aws_account_id} mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}")
+    sh("AWS_ACCOUNT_ID=${aws_account_id} AWS_REGION=${aws_region} mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}")
   }
 }
 
@@ -57,6 +58,7 @@ def build_war(repo, mvnparams) {
   script {   
     def build_txt = '../static/build.content.txt'
     def aws_account_id = sh(script: "aws sts get-caller-identity| jq -r .Account", returnStdout: true).toString().trim()
+    def aws_region = "us-west-2"
     git branch: env.DEF_BRANCH, url: repo
     sh "git remote get-url origin >> ${build_txt}"
     if (params.containsKey("branch")) {
@@ -73,7 +75,7 @@ def build_war(repo, mvnparams) {
       sh "git symbolic-ref -q --short HEAD >> ${build_txt} || git describe --tags --exact-match >> ${build_txt}"
     }
     sh "git log --pretty=medium -n 1 >> ${build_txt}"
-    sh "AWS_ACCOUNT_ID=${aws_account_id} mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}"
+    sh "AWS_ACCOUNT_ID=${aws_account_id} AWS_REGION=${aws_region} mvn -Dmaven.repo.local=${env.M2DIR} -s ${MAVEN_HOME}/conf/settings.xml clean install ${mvnparams}"
   }
 }
 

--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -19,6 +19,7 @@ def init_build() {
   script {
     sh("echo whoami")
     sh("whoami")
+    sh("docker -v")
     sh("mkdir -p static")
     def build_txt = 'static/build.content.txt'
     if (params.containsKey("branch")) {

--- a/src/org/cdlib/mrt/build/BuildFunctions.groovy
+++ b/src/org/cdlib/mrt/build/BuildFunctions.groovy
@@ -40,6 +40,7 @@ def init_build() {
     sh("groups")
     sh("newgrp docker")
     sh("groups")
+    sh("aws --version")
     sh("aws ecr get-login-password --region ${aws_region} | docker login --username AWS --password-stdin ${ecr_registry}")
     sh("export AWS_ACCOUNT_ID=${aws_account_id}")
   }


### PR DESCRIPTION
In the Jenkins config, set the following environment variables
- AWS_ACCOUNT_ID=`aws sts get-caller-identity| jq -r .Account`
- AWS_REGION=us-west-2
- ECR_REGISTRY=${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com